### PR TITLE
Modify run_scenario

### DIFF
--- a/R/run-scenario.R
+++ b/R/run-scenario.R
@@ -3,12 +3,13 @@
 #' @param scenario Name of scenario
 #' @param cmip6_model CMIP6 model parameter set to use. If `NULL` (default), use
 #'   Hector defaults.
+#'  @param return_core default is set to FALSE, so that the csv file can be written out. 
 #' @param outfile Output file. Default is `output/zz-raw-output/single-run/<scenario>-<model>.csv`
 #' @param ... Additional arguments to [set_variable()]
 #' @return Hector core object at the run end date
 #' @author Alexey Shiklomanov
 #' @export
-run_scenario <- function(scenario, cmip6_model = NULL, outfile = NULL, ...) {
+run_scenario <- function(scenario, cmip6_model = NULL, return_core = FALSE, outfile = NULL, ...) {
 
   if (is.null(outfile)) {
     modeltag <- if (is.null(cmip6_model)) "default" else cmip6_model
@@ -56,11 +57,16 @@ run_scenario <- function(scenario, cmip6_model = NULL, outfile = NULL, ...) {
     }
   )
 
-  write_output(
-    hc, outfile,
-    rcmip_scenario = scenario,
-    cmip6_model = cmip6_model
-  )
+  if(return_core){
+    hc
+  } else {
+    write_output(
+      hc, outfile,
+      rcmip_scenario = scenario,
+      cmip6_model = cmip6_model
+    )
+  }
+
 
 }
 

--- a/tests/testthat/test-run-scenario.R
+++ b/tests/testthat/test-run-scenario.R
@@ -1,16 +1,15 @@
 context("Running scenarios")
 
 test_that("Running historical scenario works", {
-  expect_warning(
-    hc <- run_scenario("historical"),
-    "Scenario historical has no data for Ftalbedo"
-  )
+
+  hc <- run_scenario("historical", return_core = TRUE)
   start <- hector::startdate(hc)
   end <- hector::enddate(hc)
   out <- fetchvars2(hc, "Ca")
   expect_true(all(out$value > 200))
 
   test_that("Reading outputs in RCMIP format works", {
+    hc <- run_scenario("historical")
     rcout <- rcmip_outputs(hc)
     expect_true("Atmospheric Concentrations|CO2" %in% rcout$variable)
     expect_true("Carbon Sequestration" %in% rcout$variable)


### PR DESCRIPTION
Add capability to return hector core or the output file within run_scenario function. Update the run scenario tests.

It looks like there had been some issues with the run_scenario test that, I've added an argument that can allow the run_scenario function to return either the results or the hector core. 