### PR TITLE
Fix N2O emission conversion

### DIFF
--- a/tests/testthat/test-run-scenario.R
+++ b/tests/testthat/test-run-scenario.R
@@ -36,12 +36,12 @@ test_that("Cores set up properly",{
 
   # Format the comparion data. 
   comp_data      <- dplyr::left_join(rcmip, true)
-  temp_comp_data <- na.omit(comp_data[comp_data$variable == hector::GLOBAL_TEMP(), ])
+  temp_comp_data <- na.omit(comp_data[comp_data$year > 2015 & comp_data$variable == hector::GLOBAL_TEMP(), ])
   temp_RMSE <- mean((temp_comp_data$rcmip - temp_comp_data$hector)^2)
   
   # Make sure that the results are within each other for some threshold. 
-  # Make sure that the temp results are within 0.01 deg C of one anohter. 
-  temp_threshold <- 0.01
+  # Make sure that the temp results are within 0.005 deg C of one anohter. 
+  temp_threshold <- 0.001
   testthat::expect_true(temp_RMSE < temp_threshold)
   
 })

--- a/tests/testthat/test-run-scenario.R
+++ b/tests/testthat/test-run-scenario.R
@@ -40,7 +40,7 @@ test_that("Cores set up properly",{
   temp_RMSE <- mean((temp_comp_data$rcmip - temp_comp_data$hector)^2)
   
   # Make sure that the results are within each other for some threshold. 
-  # Make sure that the temp results are within 0.005 deg C of one anohter. 
+  # Make sure that the temp results are within 0.001 deg C of one anohter. 
   temp_threshold <- 0.001
   testthat::expect_true(temp_RMSE < temp_threshold)
   


### PR DESCRIPTION
We were running into issues with a cold bias in the Hector temperature results. It turns out that it was related to the way that the N2O emissions were being converted. 

This has PR corrects that and add some tests. 

Before this PR is merged I would like MattN to do some diagnostic runs. And check out the global mean temp, total radiative forcing, and N2O emissions.
1. Hector rcp from ini file 
2. Hector rcp from ini file + N2O emissions from this branch 