### PR TITLE
Replace volcanic scaling with aerosol scaling in run_with_param.R

### DIFF
--- a/R/run-with-param.R
+++ b/R/run-with-param.R
@@ -48,8 +48,8 @@ run_with_param <- function(scenario, pS, pdiff, palpha,
   )
   hector::setvar(
     core, NA,
-    hector::VOLCANIC_SCALE(), palpha,
-    hector::getunits(hector::VOLCANIC_SCALE())
+    hector::AERO_SCALE(), palpha,
+    hector::getunits(hector::AERO_SCALE())
   )
   hector::run(core, maxdate)
   if (is.null(isamp)) isamp <- uuid::UUIDgenerate()
@@ -63,7 +63,7 @@ run_with_param <- function(scenario, pS, pdiff, palpha,
   if (include_params) {
     write_output(core, outfile, param_ecs = pS,
                  param_diffusivity = pdiff,
-                 param_volscl = palpha,
+                 param_aerscl = palpha,
                  isamp = isamp,
                  ...)
   } else {

--- a/scripts/01-run-simulations.R
+++ b/scripts/01-run-simulations.R
@@ -45,7 +45,7 @@ read_probability_scenario <- function(scenario_files) {
   scenariofile <- fs::path(outdir, paste0(scenario, ".fst"))
   fst::write_fst(values, scenariofile)
   rm(values)
-  params <- unique(dat[, .(isamp, param_ecs, param_diffusivity, param_volscl)])
+  params <- unique(dat[, .(isamp, param_ecs, param_diffusivity, param_aerscl)])
   rm(dat)
   paramfile <- fs::path(outdir, paste0("params.", scenario, ".fst"))
   fst::write_fst(params, paramfile)


### PR DESCRIPTION
Addresses #9 . Maybe not the preferred fix, if you would like to keep the ability to adjust volcanic forcing in this function.